### PR TITLE
Adding rendering of cross-project issues

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -10,6 +10,10 @@ Dispatcher.to_prepare :redmine_issue_dependency do
   unless Issue.included_modules.include? RedmineBetterGanttChart::IssueDependencyPatch
     Issue.send(:include, RedmineBetterGanttChart::IssueDependencyPatch)
   end
+
+  unless Issue.included_modules.include? RedmineBetterGanttChart::IssuePatch
+    Issue.send(:include, RedmineBetterGanttChart::IssuePatch)
+  end
   
   unless Project.included_modules.include? RedmineBetterGanttChart::ProjectPatch
     Project.send(:include, RedmineBetterGanttChart::ProjectPatch)

--- a/lib/redmine_better_gantt_chart/issue_patch.rb
+++ b/lib/redmine_better_gantt_chart/issue_patch.rb
@@ -1,0 +1,22 @@
+module RedmineBetterGanttChart
+  module IssuePatch
+    def self.included(base) # :nodoc:
+      base.send(:include, InstanceMethods)
+    end
+
+    module InstanceMethods
+      # Defines whether this issue is marked as external from the current project
+      def is_external=(flag)
+        @external = flag
+      end
+
+       # Returns whether this issue is marked as external from the current project
+      def is_external
+        if @external == nil
+          return false
+        end
+        @external
+      end
+    end
+  end
+end

--- a/lib/redmine_better_gantt_chart/project_patch.rb
+++ b/lib/redmine_better_gantt_chart/project_patch.rb
@@ -11,6 +11,7 @@ module RedmineBetterGanttChart
           related_issues = []
           issue.relations.each do |relation|
             related_issue = relation.other_issue(issue)
+            related_issue.is_external = true
             related_issues << related_issue unless related_issue.project == issue.project
           end
           return related_issues


### PR DESCRIPTION
Hi,

I've just added a new feature to your plugin.

Now cross-project related issues are displayed as well, because such an information has been requested by some customers of my company.
You can have an overview in this screenshot: http://img34.imageshack.us/img34/9053/ganttcrossprojectissues.png

Are you interested as well in this new feature?

Note that I'm a ruby noob so there might some code to review. Unfortunately I had to override several Redmine core methods… As you've probably noticed, the gantt core library is not well designed to be extended.

Please let me know what you think.

Cheers,
Jeremy Subtil
