### PR TITLE
[redmine 2.1 support] Remove test-unit Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,5 @@ group :test do
   gem 'rspec-rails', "~>1.3"
   gem 'factory_girl', "~>1.3"
   gem 'database_cleaner'
-  gem 'test-unit', '1.2.3'
   gem 'RedCloth', "~> 4.2.9"
 end


### PR DESCRIPTION
Redmine 2.1 now includes test-unit in its Gemfile, so including it again here pops up the following Bundle error:

`You cannot specify the same gem twice with different version requirements. You specified: test-unit (>= 0) and test-unit (= 1.2.3)`
