### PR TITLE
Avoid an error if either the issue start_date or the due_date are nil.

### DIFF
--- a/lib/redmine_better_gantt_chart/issue_dependency_patch.rb
+++ b/lib/redmine_better_gantt_chart/issue_dependency_patch.rb
@@ -151,7 +151,8 @@ module RedmineBetterGanttChart
             if options[:parent]
               new_dates[other_attr] = issue.send(other_attr)
             else
-              new_dates[other_attr] = RedmineBetterGanttChart::Calendar.workdays_from_date(issue.send(other_attr), new_dates[changed_attr] - issue.send(changed_attr))
+              shift = issue.send(changed_attr) ? new_dates[changed_attr] - issue.send(changed_attr) : 0
+              new_dates[other_attr] = RedmineBetterGanttChart::Calendar.workdays_from_date(issue.send(other_attr), shift)
             end
           end
         end


### PR DESCRIPTION
This situation can happen on existing data which has a set due_date
but no start_date. The code would then error out with

```
TypeError: expected numeric or date in
[RUBY_ROOT]/lib/ruby/1.8/date.rb:1252:in minus_without_duration
[GEM_ROOT]/gems/activesupport-2.3.15/lib/active_support/core_ext/date/calculations.rb:88:in -
[PROJECT_ROOT]/vendor/plugins/redmine_better_gantt_chart/lib/redmine_better_gantt_chart/issue_dependency_patch.rb:154:in cache_change
[PROJECT_ROOT]/vendor/plugins/redmine_better_gantt_chart/lib/redmine_better_gantt_chart/issue_dependency_patch.rb:69:in reschedule_dependent_issue
[PROJECT_ROOT]/vendor/plugins/redmine_better_gantt_chart/lib/redmine_better_gantt_chart/issue_dependency_patch.rb:87:in process_child_issues
[GEM_ROOT]/gems/activerecord-2.3.15/lib/active_record/named_scope.rb:114:in each
[GEM_ROOT]/gems/activerecord-2.3.15/lib/active_record/named_scope.rb:114:in __send__
[GEM_ROOT]/gems/activerecord-2.3.15/lib/active_record/named_scope.rb:114:in each
[PROJECT_ROOT]/vendor/plugins/redmine_better_gantt_chart/lib/redmine_better_gantt_chart/issue_dependency_patch.rb:78:in process_child_issues
[PROJECT_ROOT]/vendor/plugins/redmine_better_gantt_chart/lib/redmine_better_gantt_chart/issue_dependency_patch.rb:70:in reschedule_dependent_issue
[PROJECT_ROOT]/vendor/plugins/redmine_better_gantt_chart/lib/redmine_better_gantt_chart/issue_dependency_patch.rb:24:in reschedule_following_issues
[PROJECT_ROOT]/vendor/plugins/redmine_better_gantt_chart/lib/redmine_better_gantt_chart/issue_dependency_patch.rb:33:in cache_and_apply_changes
[PROJECT_ROOT]/vendor/plugins/redmine_better_gantt_chart/lib/redmine_better_gantt_chart/issue_dependency_patch.rb:23:in reschedule_following_issues
```
