### PR TITLE
Only weekend (Saturday and Sunday) has enabled background color

### DIFF
--- a/app/views/gantts/show.html.erb
+++ b/app/views/gantts/show.html.erb
@@ -171,7 +171,7 @@
                   @gantt.params.merge(:year => year),
                   :title => "#{year}" %>
     <% end %>
-    <% 
+    <%
       left = left + width + 1
     %>
   <% end %>
@@ -276,8 +276,8 @@
         style += "height: #{height}px;"
         style += "text-align:center;"
         style += "font-size:0.7em;"
-        style += 'background:#f1f1f1;' if (@gantt.work_on_weekends && wday > 5)
-        style += 'border-left: 1px solid #c6c6c6;' if (!@gantt.work_on_weekends && wday == 1)
+        style += 'background:#f1f1f1;' if (@gantt.work_on_weekends && day.cwday > 5)
+        style += 'border-left: 1px solid #c6c6c6;' if (!@gantt.work_on_weekends && day.cwday == 1)
       %>
       <%= content_tag(:div, :style => style, :class => "gantt_hdr") do %>
         <%= day_letter(wday) %>


### PR DESCRIPTION
Hello :)
When flag of work_on_weekends is TRUE, Background color is applied in all days.
Please see image below.  
![bug](https://f.cloud.github.com/assets/1174586/1208200/640b67ae-25ca-11e3-9a2e-3e8da4e49f80.png)

Only weekend (Saturday and Sunday) has enabled background color.
At the same time, also when flag of work_on_weekends is FALSE, fix a condition.
