### PR TITLE
fixing issue missing basic_object on activesupport 4.2.0

### DIFF
--- a/lib/redmine_better_gantt_chart/active_record/callback_extensions_for_rails4.rb
+++ b/lib/redmine_better_gantt_chart/active_record/callback_extensions_for_rails4.rb
@@ -1,8 +1,8 @@
-require 'active_support/proxy_object'
+require 'active_support/basic_object'
 
 module RedmineBetterGanttChart
   module ActiveRecord
-    class WithoutCallbacks < ActiveSupport::ProxyObject
+    class WithoutCallbacks < ActiveSupport::BasicObject
       def initialize(target, types)
         @target = target
         @types  = types


### PR DESCRIPTION
I have fixed this issue by change basic_object to proxy_object